### PR TITLE
Log errors in non-dereffed futures

### DIFF
--- a/server/src/lsp4clj/core.clj
+++ b/server/src/lsp4clj/core.clj
@@ -102,7 +102,11 @@
 
   (^void didSave [_ ^DidSaveTextDocumentParams params]
     (future
-      (handle-notification params feature-handler/did-save handler))
+      (try
+        (handle-notification params feature-handler/did-save handler)
+        (catch Throwable e
+          (logger/error e)
+          (throw e))))
     (CompletableFuture/completedFuture 0))
 
   (^void didClose [_ ^DidCloseTextDocumentParams params]
@@ -212,7 +216,11 @@
   WorkspaceService
   (^CompletableFuture executeCommand [_ ^ExecuteCommandParams params]
     (future
-      (handle-notification params feature-handler/execute-command handler))
+      (try
+        (handle-notification params feature-handler/execute-command handler)
+        (catch Throwable e
+          (logger/error e)
+          (throw e))))
     (CompletableFuture/completedFuture 0))
 
   (^void didChangeConfiguration [_ ^DidChangeConfigurationParams params]

--- a/server/src/lsp4clj/core.clj
+++ b/server/src/lsp4clj/core.clj
@@ -318,7 +318,7 @@
     (LSPWorkspaceService. feature-handler)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn tee-system-in [^java.io.InputStream system-in]
+(defn ^:deprecated tee-system-in [^java.io.InputStream system-in]
   (let [buffer-size 1024
         os (java.io.PipedOutputStream.)
         is (java.io.PipedInputStream. os)]
@@ -335,7 +335,7 @@
     is))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn tee-system-out [^java.io.OutputStream system-out]
+(defn ^:deprecated tee-system-out [^java.io.OutputStream system-out]
   (let [buffer-size 1024
         is (java.io.PipedInputStream.)
         os (java.io.PipedOutputStream. is)]


### PR DESCRIPTION
Exceptions in futures that are never dereffed are essentially lost, unless they are explicitly logged. They are lost because Clojure catches them and holds them, waiting to re-throw them when the future is dereffed. This adds logging for a few futures in lsp4clj.core.

It also deprecates some buggy helper functions. These functions are intended for debugging the input to and output from LSP. However, they have several deficiencies.

First, LSP has built-in tools for tracing its I/O. Prefer the 6 argument builder for an LSP Launcher, which accepts a PrintWriter for tracing.
E.g.

```clojure
(let [tracer (java.io.PrintWriter. (io/writer (io/file "path/to/a/log/file")))]
 (Launcher/createLauncher server ClojureLanguageClient is os false tracer))
```

Second, they will throw a "write end dead" java.io.IOException. It doesn't happen on my MacBook Pro, but happens reliably on Github Actions (ubuntu-latest) after about 30 seconds of use.