### PR TITLE
Fix coercion of resolved completion items

### DIFF
--- a/src/lsp4clj/coercer.clj
+++ b/src/lsp4clj/coercer.clj
@@ -46,14 +46,17 @@
                                     completion-item-kind->enum-val
                                     (s/conformer completion-item-kind->enum-val)))
 
-(def insert-text-format-enum
+(def insert-text-format->enum-val
   {:plaintext 1
    :snippet 2})
 
+(def enum-val->insert-text-format
+  (set/map-invert insert-text-format->enum-val))
+
 (s/def :completion-item/insert-text-format
   (s/and keyword?
-         insert-text-format-enum
-         (s/conformer insert-text-format-enum)))
+         insert-text-format->enum-val
+         (s/conformer insert-text-format->enum-val)))
 
 (s/def ::new-text string?)
 (s/def ::text-edit (s/keys :req-un [::new-text ::range]))
@@ -83,8 +86,14 @@
          enum-val->completion-item-kind
          (s/conformer enum-val->completion-item-kind)))
 
+(s/def :input.completion-item/insert-text-format
+  (s/and integer?
+         enum-val->insert-text-format
+         (s/conformer enum-val->insert-text-format)))
+
 (s/def ::input.completion-item
-  (s/keys :opt-un [:input.completion-item/kind]))
+  (s/keys :opt-un [:input.completion-item/kind
+                   :input.completion-item/insert-text-format]))
 
 (s/def ::version (s/and integer? (s/conformer int)))
 (s/def ::uri string?)


### PR DESCRIPTION
Coerce an integer `CompletionItem.insertTextFormat`—which is provided as input to `completionItem/resolve`—into a keyword. Then the keyword can be coerced back to an integer later, when `completionItem/resolve` returns the resolved CompletionItem.