### PR TITLE
Deprecate server/stdio-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support communication through a socket, as an alternative to stdio. #1
+- Deprecate `lsp4clj.server/stdio-server`. Use the identical `lsp4clj.io-server/server` or `lsp4clj.io-server/stdio-server` instead.
 
 ## v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ lsp4clj reads and writes from stdio, parsing JSON-RPC according to the LSP spec.
 To initialize a server that will read from stdin and write to stdout:
 
 ```clojure
-(lsp4clj.server/stdio-server {:in System/in, :out System/out})
+(lsp4clj.io-server/stdio-server)
 ```
 
 The returned server will have a core.async `:log-ch`, from which you can read server logs (vectors beginning with a log level).
@@ -112,9 +112,7 @@ This will start listening on the provided port, blocking until a client makes a 
 As you are implementing, you may want to trace incoming and outgoing messages. Initialize the server with `:trace? true` and then read traces (two element vectors, beginning with the log level `:debug` and ending with a string, the trace itself) off its `:trace-ch`.
 
 ```clojure
-(let [server (lsp4clj.server/stdio-server {:trace? true
-                                           :in System/in
-                                           :out System/out})]
+(let [server (lsp4clj.io-server/stdio-server {:trace? true})]
   (async/go-loop []
     (when-let [[level trace] (async/<! (:trace-ch server))]
       (logger/log level trace)

--- a/src/lsp4clj/io_server.clj
+++ b/src/lsp4clj/io_server.clj
@@ -1,0 +1,23 @@
+(ns lsp4clj.io-server
+  (:require
+   [lsp4clj.server :as server]
+   [lsp4clj.json-rpc :as json-rpc]))
+
+(set! *warn-on-reflection* true)
+
+(defn server
+  "Starts a chan-server, reading and writing from `:in` and `:out` and
+  transferring messages to `:input-ch` and `:output-ch`."
+  [{:keys [in out] :as opts}]
+  (server/chan-server (assoc opts
+                             :input-ch (json-rpc/input-stream->input-chan in)
+                             :output-ch (json-rpc/output-stream->output-chan out))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn stdio-server
+  "Starts a server reading from stdin and writing to stdout."
+  ([] (stdio-server {}))
+  ([{:keys [in out] :as opts}]
+   (server (assoc opts
+                  :in (or in System/in)
+                  :out (or out System/out)))))

--- a/src/lsp4clj/json_rpc.clj
+++ b/src/lsp4clj/json_rpc.clj
@@ -1,7 +1,12 @@
 (ns lsp4clj.json-rpc
-  "Models LSP JSON-RPC as core.async channels of messages (Clojure hashmaps).
+  "Follows the LSP spec for reading and writing JSON-RPC messages. Converts the
+  messages to and from Clojure hashmaps and shuttles them to core.async
+  channels.
 
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseProtocol"
+  ;; TODO: after lsp4clj.server/stdio-server is removed, consider merging this
+  ;; namespace into lsp4clj.io-server. That will centralize everything that
+  ;; deals with Input and Output Streams.
   (:require
    [camel-snake-kebab.core :as csk]
    [camel-snake-kebab.extras :as cske]

--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -251,7 +251,7 @@
 (defn stdio-server
   "DEPRECATED: Will be removed in a future release. Prefer
   lsp4clj.io-server/server or lsp4clj.io-server/stdio-server."
-  {:deprecated true}
+  {:deprecated "Use lsp4clj.io-server/server instead"}
   [{:keys [in out] :as opts}]
   (chan-server (assoc opts
                       :input-ch (json-rpc/input-stream->input-chan in)

--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -247,7 +247,11 @@
      :pending-requests* (atom {})
      :join (promise)}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn stdio-server
+  "DEPRECATED: Will be removed in a future release. Prefer
+  lsp4clj.io-server/server or lsp4clj.io-server/stdio-server."
+  {:deprecated true}
   [{:keys [in out] :as opts}]
   (chan-server (assoc opts
                       :input-ch (json-rpc/input-stream->input-chan in)

--- a/src/lsp4clj/socket_server.clj
+++ b/src/lsp4clj/socket_server.clj
@@ -1,6 +1,6 @@
 (ns lsp4clj.socket-server
   (:require
-   [lsp4clj.server :as server])
+   [lsp4clj.io-server :as io-server])
   (:import
    [java.net InetAddress ServerSocket Socket]))
 
@@ -41,7 +41,7 @@
          on-close #(do
                      (.close conn)
                      (.close socket))]
-     (server/stdio-server (assoc opts
-                                 :in (.getInputStream conn)
-                                 :out (.getOutputStream conn)
-                                 :on-close on-close)))))
+     (io-server/server (assoc opts
+                              :in (.getInputStream conn)
+                              :out (.getOutputStream conn)
+                              :on-close on-close)))))

--- a/test/lsp4clj/io_server_test.clj
+++ b/test/lsp4clj/io_server_test.clj
@@ -1,0 +1,39 @@
+(ns lsp4clj.io-server-test
+  (:require
+   [clojure.core.async :as async]
+   [clojure.test :refer [deftest is]]
+   [lsp4clj.io-server :as io-server]
+   [lsp4clj.json-rpc :as json-rpc]
+   [lsp4clj.json-rpc.messages :as messages]
+   [lsp4clj.server :as server]
+   [lsp4clj.test-helper :as h]))
+
+(set! *warn-on-reflection* true)
+
+(deftest server-test
+  (let [server-input-stream (java.io.PipedInputStream.)
+        server-output-stream (java.io.PipedOutputStream.)
+        client-input-stream (java.io.PipedInputStream. server-output-stream)
+        client-output-stream (java.io.PipedOutputStream. server-input-stream)
+        server (io-server/server {:in server-input-stream :out server-output-stream})
+        client-input-ch (json-rpc/input-stream->input-chan client-input-stream)
+        client-output-ch (json-rpc/output-stream->output-chan client-output-stream)
+        join (server/start server nil)]
+    ;; client initiates request
+    (async/put! client-output-ch (messages/request 1 "foo" {}))
+    ;; server responds
+    (is (= {:jsonrpc "2.0",
+            :id 1,
+            :error {:code -32601,
+                    :message "Method not found",
+                    :data {:method "foo"}}}
+           (h/assert-take client-input-ch)))
+    ;; server initiates notification
+    (server/send-notification server "bar" {:key "value"})
+    ;; client receives
+    (is (= {:jsonrpc "2.0",
+            :method "bar",
+            :params {:key "value"}}
+           (h/assert-take client-input-ch)))
+    (server/shutdown server)
+    (is (= :done @join))))


### PR DESCRIPTION
This introduces a new namespace `lsp4clj.io-server`. It deprecates `lsp4clj.server/stdio-server` and suggests `lsp4clj.io-server/server`, which has identical behavior, as a replacement. It also introduces `lsp4clj.io-server/stdio-server`, which uses System/in and System/out by default, providing a smaller API for servers. Finally, it adds integration level tests for an io-server, something which we only had disconnected unit level test for before.

This is the first step in isolating the parts of the code base that use Java interop, a goal which was first observed in [discussions](https://github.com/clojure-lsp/lsp4clj/pull/16#issuecomment-1214206756) around #16. I have a follow-up commit which removes the deprecated function and merges `lsp4clj.json-rpc` (which has all the InputStream and OutputStream interop) into `io-server`. That will leave `lsp4clj.server` more (though not entirely) independent of Java. That should be part of a subsequent release so that we have at least one release with the deprecation warnings.