### PR TITLE
Allow servers to place requests while receiving

### DIFF
--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -99,32 +99,66 @@
   (let [{:keys [code message]} (json-rpc.messages/error-codes error-code)]
     (format "%s: %s (%s)" description message code)))
 
-(defn ^:private receive-message
-  [server context message]
-  (let [message-type (coercer/input-message-type message)
-        request? (identical? :request message-type)]
-    (try
-      (let [response
-            (discarding-stdout
+(defn ^:private log-error-receiving [server e message]
+  (protocols.endpoint/log server :error e
+                          (str (format-error-code "Error receiving message" :internal-error) "\n"
+                               (select-keys message [:id :method]))))
+
+(defn ^:private start-pipeline [input-ch output-ch server context]
+  ;; Fork the input off to two streams of work, the input initiated by the
+  ;; client (the client's requests and notifications) and the input initiated by
+  ;; the server (the client's responses). Process each stream one message at a
+  ;; time, but independently. The streams must be processed indepedently so that
+  ;; while receiving a request, the server can send a request and receive the
+  ;; response before sending its response to the original request. This happens,
+  ;; for example, when servers send showMessageRequest while processing a
+  ;; request they have received.
+  (let [server-initiated-ch (async/chan 1)
+        client-initiated-ch (async/chan 1)
+        pipeline
+        (async/go-loop []
+          (if-let [message (async/<! input-ch)]
+            (let [message-type (coercer/input-message-type message)]
               (case message-type
                 (:parse-error :invalid-request)
                 (protocols.endpoint/log server :error (format-error-code "Error reading message" message-type))
-                :request
-                (protocols.endpoint/receive-request server context message)
+                (:request :notification)
+                (async/>! client-initiated-ch [message-type message])
                 (:response.result :response.error)
-                (protocols.endpoint/receive-response server message)
-                :notification
-                (protocols.endpoint/receive-notification server context message)))]
-        ;; Ensure server only responds to requests
-        (when request? response))
-      (catch Throwable e
-        (let [message-basics (select-keys message [:id :method])]
-          (protocols.endpoint/log server :error e (str (format-error-code "Error receiving message" :internal-error) "\n"
-                                                       message-basics))
-          (when request?
-            (->> message-basics
-                 (json-rpc.messages/standard-error-result :internal-error)
-                 (json-rpc.messages/response (:id message)))))))))
+                (async/>! server-initiated-ch message))
+              (recur))
+            (do
+              (async/close! client-initiated-ch)
+              (async/close! server-initiated-ch)
+              (async/close! output-ch))))]
+    ;; a thread so server can use >!! and so that we can use (>!! output-ch) to
+    ;; respect back pressure from clients that are slow to read.
+    (async/thread
+      (when-let [[message-type message] (async/<!! client-initiated-ch)]
+        (discarding-stdout
+          ;; TODO: return error until initialize response is sent?
+          ;; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
+          (case message-type
+            :request
+            (async/>!! output-ch
+                       (try
+                         (protocols.endpoint/receive-request server context message)
+                         (catch Throwable e
+                           (log-error-receiving server e message)
+                           (->> (select-keys message [:id :method])
+                                (json-rpc.messages/standard-error-result :internal-error)
+                                (json-rpc.messages/response (:id message))))))
+            :notification
+            (try
+              (protocols.endpoint/receive-notification server context message)
+              (catch Throwable e
+                (log-error-receiving server e message)))))
+        (recur)))
+    (async/go-loop []
+      (when-let [message (async/<! server-initiated-ch)]
+        (protocols.endpoint/receive-response server message)
+        (recur)))
+    pipeline))
 
 ;; Expose endpoint methods to language servers
 
@@ -158,13 +192,7 @@
                        join]
   protocols.endpoint/IEndpoint
   (start [this context]
-    (let [pipeline (async/pipeline-blocking
-                     1 ;; no parallelism, to preserve order of client messages
-                     output-ch
-                     ;; TODO: return error until initialize request is received? https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
-                     ;; `keep` means we do not reply to responses and notifications
-                     (keep #(receive-message this context %))
-                     input-ch)]
+    (let [pipeline (start-pipeline input-ch output-ch this context)]
       (async/go
         ;; Wait for pipeline to close. This indicates input-ch was closed and
         ;; that now output-ch is closed.

--- a/test/lsp4clj/io_server_test.clj
+++ b/test/lsp4clj/io_server_test.clj
@@ -13,7 +13,7 @@
 (defn ^:private message-lines [arr]
   (string/join "\r\n" arr))
 
-(defn mock-input-stream [input]
+(defn mock-input-stream [^String input]
   (java.io.ByteArrayInputStream. (.getBytes input "utf-8")))
 
 (deftest output-stream-should-camel-case-output


### PR DESCRIPTION
Messages are read off the input channel one at a time. In the case of
requests, the pipeline is blocked until the request completes. But this
causes a bug. During an inbound request a server can place an outbound
request. Because the pipeline is blocked, the client's response can't be
received until the first request finishes. If the server blocks waiting
for a response without a timeout, we end up deadlocked. And even if the
server uses a timeout, it doesn't receive the response in time to use
it.

This splits the input stream in two. The inbound messages that are
initiated by the client (inbound requests and notifications) are
processed in one stream, and inbound messages initiated by the server
(inbound responses) are processed in another. This allows a server to
receive a response even while it's waiting to finish processing a
request.

This commit doesn't change the number of threads used. Before, when we
were using pipeline-blocking, one thread was created to processes all
inbound messages. Now one thread processes all client-initiated inbound
messages. The rest of the input channel message negotiation is handled
in go blocks.

This thread is necessary so that we can block writes to the output
channel, to respect backpressure from clients that are slow to read.

Some observations about this change...

1. The new `start-pipeline` exposes a lot of the internals of what was happening in `pipeline-blocking`. I'm not sure how to feel about this. From one perspective, `pipeline-blocking` was elegantly succinct. From another, it was opaque, and probably overkill since we weren't using any parallelism.
2. This change clarifies that we have to use blocking puts `>!!` exactly (and only) when we interact with the output chan. There might be a way to enforce that requirement in one central location, but I couldn't figure out how to do it.

