### PR TITLE
Put IO <-> chan conversion back into its own namespace

### DIFF
--- a/src/lsp4clj/io_chan.clj
+++ b/src/lsp4clj/io_chan.clj
@@ -1,0 +1,123 @@
+(ns lsp4clj.io-chan
+  (:require
+   [camel-snake-kebab.core :as csk]
+   [camel-snake-kebab.extras :as cske]
+   [cheshire.core :as json]
+   [clojure.core.async :as async]
+   [clojure.string :as string])
+  (:import
+   (java.io EOFException InputStream OutputStream)))
+
+(set! *warn-on-reflection* true)
+
+;;;; IO <-> chan
+
+;; Follow the LSP spec for reading and writing JSON-RPC messages. Convert the
+;; messages to and from Clojure hashmaps and shuttle them to core.async
+;; channels.
+
+;; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseProtocol
+
+(defn ^:private read-n-bytes [^InputStream input content-length charset-s]
+  (let [buffer (byte-array content-length)]
+    (loop [total-read 0]
+      (when (< total-read content-length)
+        (let [new-read (.read input buffer total-read (- content-length total-read))]
+          (when (< new-read 0)
+            ;; TODO: return nil instead?
+            (throw (EOFException.)))
+          (recur (+ total-read new-read)))))
+    (String. ^bytes buffer ^String charset-s)))
+
+(defn ^:private parse-header [line headers]
+  (let [[h v] (string/split line #":\s*" 2)]
+    (assoc headers h v)))
+
+(defn ^:private parse-charset [content-type]
+  (or (when content-type
+        (when-let [[_ charset] (re-find #"(?i)charset=(.*)$" content-type)]
+          (when (not= "utf8" charset)
+            charset)))
+      "utf-8"))
+
+(defn ^:private read-message [input headers keyword-function]
+  (try
+    (let [content-length (parse-long (get headers "Content-Length"))
+          charset-s (parse-charset (get headers "Content-Type"))
+          content (read-n-bytes input content-length charset-s)]
+      (json/parse-string content keyword-function))
+    (catch Exception _
+      :parse-error)))
+
+(defn ^:private kw->camelCaseString
+  "Convert keywords to camelCase strings, but preserve capitalization of things
+  that are already strings."
+  [k]
+  (cond-> k (keyword? k) csk/->camelCaseString))
+
+(def ^:private write-lock (Object.))
+
+(defn ^:private write-message [^OutputStream output msg]
+  (let [content (json/generate-string (cske/transform-keys kw->camelCaseString msg))
+        content-bytes (.getBytes content "utf-8")]
+    (locking write-lock
+      (doto output
+        (.write (-> (str "Content-Length: " (count content-bytes) "\r\n"
+                         "\r\n")
+                    (.getBytes "US-ASCII"))) ;; headers are in ASCII, not UTF-8
+        (.write content-bytes)
+        (.flush)))))
+
+(defn ^:private read-header-line
+  "Reads a line of input. Blocks if there are no messages on the input."
+  [^InputStream input]
+  (let [s (java.lang.StringBuilder.)]
+    (loop []
+      (let [b (.read input)] ;; blocks, presumably waiting for next message
+        (case b
+          -1 ::eof ;; end of stream
+          #_lf 10 (str s) ;; finished reading line
+          #_cr 13 (recur) ;; ignore carriage returns
+          (do (.append s (char b)) ;; byte == char because header is in US-ASCII
+              (recur)))))))
+
+(defn input-stream->input-chan
+  "Returns a channel which will yield parsed messages that have been read off
+  the `input`. When the input is closed, closes the channel. By default when the
+  channel closes, will close the input, but can be determined by `close?`.
+
+  Reads in a thread to avoid blocking a go block thread."
+  ([input] (input-stream->input-chan input {}))
+  ([^InputStream input {:keys [close? keyword-function]
+                        :or {close? true, keyword-function csk/->kebab-case-keyword}}]
+   (let [messages (async/chan 1)]
+     (async/thread
+       (loop [headers {}]
+         (let [line (read-header-line input)]
+           (cond
+             ;; input closed; also close channel
+             (= line ::eof) (async/close! messages)
+             ;; a blank line after the headers indicates start of message
+             (string/blank? line) (if (async/>!! messages (read-message input headers keyword-function))
+                                    ;; wait for next message
+                                    (recur {})
+                                    ;; messages closed
+                                    (when close? (.close input)))
+             :else (recur (parse-header line headers))))))
+     messages)))
+
+(defn output-stream->output-chan
+  "Returns a channel which expects to have messages put on it. nil values are
+  not allowed. Serializes and writes the messages to the output. When the
+  channel is closed, closes the output.
+
+  Writes in a thread to avoid blocking a go block thread."
+  [^OutputStream output]
+  (let [messages (async/chan 1)]
+    (async/thread
+      (with-open [writer output] ;; close output when channel closes
+        (loop []
+          (when-let [msg (async/<!! messages)]
+            (write-message writer msg)
+            (recur)))))
+    messages))

--- a/src/lsp4clj/io_server.clj
+++ b/src/lsp4clj/io_server.clj
@@ -1,127 +1,9 @@
 (ns lsp4clj.io-server
   (:require
-   [camel-snake-kebab.core :as csk]
-   [camel-snake-kebab.extras :as cske]
-   [cheshire.core :as json]
-   [clojure.core.async :as async]
-   [clojure.string :as string]
-   [lsp4clj.server :as server])
-  (:import
-   [java.io EOFException InputStream OutputStream]))
+   [lsp4clj.io-chan :as io-chan]
+   [lsp4clj.server :as server]))
 
 (set! *warn-on-reflection* true)
-
-;;;; IO <-> chan
-
-;; Follow the LSP spec for reading and writing JSON-RPC messages. Convert the
-;; messages to and from Clojure hashmaps and shuttle them to core.async
-;; channels.
-
-;; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseProtocol
-
-(defn ^:private read-n-bytes [^InputStream input content-length charset-s]
-  (let [buffer (byte-array content-length)]
-    (loop [total-read 0]
-      (when (< total-read content-length)
-        (let [new-read (.read input buffer total-read (- content-length total-read))]
-          (when (< new-read 0)
-            ;; TODO: return nil instead?
-            (throw (EOFException.)))
-          (recur (+ total-read new-read)))))
-    (String. ^bytes buffer ^String charset-s)))
-
-(defn ^:private parse-header [line headers]
-  (let [[h v] (string/split line #":\s*" 2)]
-    (assoc headers h v)))
-
-(defn ^:private parse-charset [content-type]
-  (or (when content-type
-        (when-let [[_ charset] (re-find #"(?i)charset=(.*)$" content-type)]
-          (when (not= "utf8" charset)
-            charset)))
-      "utf-8"))
-
-(defn ^:private read-message [input headers keyword-function]
-  (try
-    (let [content-length (parse-long (get headers "Content-Length"))
-          charset-s (parse-charset (get headers "Content-Type"))
-          content (read-n-bytes input content-length charset-s)]
-      (json/parse-string content keyword-function))
-    (catch Exception _
-      :parse-error)))
-
-(defn ^:private kw->camelCaseString
-  "Convert keywords to camelCase strings, but preserve capitalization of things
-  that are already strings."
-  [k]
-  (cond-> k (keyword? k) csk/->camelCaseString))
-
-(def ^:private write-lock (Object.))
-
-(defn ^:private write-message [^OutputStream output msg]
-  (let [content (json/generate-string (cske/transform-keys kw->camelCaseString msg))
-        content-bytes (.getBytes content "utf-8")]
-    (locking write-lock
-      (doto output
-        (.write (-> (str "Content-Length: " (count content-bytes) "\r\n"
-                         "\r\n")
-                    (.getBytes "US-ASCII"))) ;; headers are in ASCII, not UTF-8
-        (.write content-bytes)
-        (.flush)))))
-
-(defn ^:private read-header-line
-  "Reads a line of input. Blocks if there are no messages on the input."
-  [^InputStream input]
-  (let [s (java.lang.StringBuilder.)]
-    (loop []
-      (let [b (.read input)] ;; blocks, presumably waiting for next message
-        (case b
-          -1 ::eof ;; end of stream
-          #_lf 10 (str s) ;; finished reading line
-          #_cr 13 (recur) ;; ignore carriage returns
-          (do (.append s (char b)) ;; byte == char because header is in US-ASCII
-              (recur)))))))
-
-(defn input-stream->input-chan
-  "Returns a channel which will yield parsed messages that have been read off
-  the `input`. When the input is closed, closes the channel. By default when the
-  channel closes, will close the input, but can be determined by `close?`.
-
-  Reads in a thread to avoid blocking a go block thread."
-  ([input] (input-stream->input-chan input {}))
-  ([^InputStream input {:keys [close? keyword-function]
-                        :or {close? true, keyword-function csk/->kebab-case-keyword}}]
-   (let [messages (async/chan 1)]
-     (async/thread
-       (loop [headers {}]
-         (let [line (read-header-line input)]
-           (cond
-             ;; input closed; also close channel
-             (= line ::eof) (async/close! messages)
-             ;; a blank line after the headers indicates start of message
-             (string/blank? line) (if (async/>!! messages (read-message input headers keyword-function))
-                                    ;; wait for next message
-                                    (recur {})
-                                    ;; messages closed
-                                    (when close? (.close input)))
-             :else (recur (parse-header line headers))))))
-     messages)))
-
-(defn output-stream->output-chan
-  "Returns a channel which expects to have messages put on it. nil values are
-  not allowed. Serializes and writes the messages to the output. When the
-  channel is closed, closes the output.
-
-  Writes in a thread to avoid blocking a go block thread."
-  [^OutputStream output]
-  (let [messages (async/chan 1)]
-    (async/thread
-      (with-open [writer output] ;; close output when channel closes
-        (loop []
-          (when-let [msg (async/<!! messages)]
-            (write-message writer msg)
-            (recur)))))
-    messages))
 
 ;;;; Create server
 
@@ -131,8 +13,8 @@
   `:out`."
   [{:keys [in out] :as opts}]
   (server/chan-server (assoc opts
-                             :input-ch (input-stream->input-chan in)
-                             :output-ch (output-stream->output-chan out))))
+                             :input-ch (io-chan/input-stream->input-chan in)
+                             :output-ch (io-chan/output-stream->output-chan out))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn stdio-server

--- a/test/lsp4clj/io_chan_test.clj
+++ b/test/lsp4clj/io_chan_test.clj
@@ -1,0 +1,113 @@
+(ns lsp4clj.io-chan-test
+  (:require
+   [clojure.core.async :as async]
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing]]
+   [lsp4clj.io-chan :as io-chan]
+   [lsp4clj.test-helper :as h]))
+
+(set! *warn-on-reflection* true)
+
+(defn ^:private message-lines [arr]
+  (string/join "\r\n" arr))
+
+(defn mock-input-stream [^String input]
+  (java.io.ByteArrayInputStream. (.getBytes input "utf-8")))
+
+(deftest output-stream-should-camel-case-output
+  (let [output-stream (java.io.ByteArrayOutputStream.)
+        output-ch (io-chan/output-stream->output-chan output-stream)]
+    (async/>!! output-ch {:parent-key {:child-key "child value"}})
+    (async/close! output-ch)
+    (Thread/sleep 200)
+    (is (= (message-lines ["Content-Length: 40"
+                           ""
+                           "{\"parentKey\":{\"childKey\":\"child value\"}}"])
+           (.toString output-stream "utf-8")))))
+
+(deftest output-stream-should-not-camel-case-string-map-keys
+  (let [output-stream (java.io.ByteArrayOutputStream.)
+        output-ch (io-chan/output-stream->output-chan output-stream)]
+    (async/>!! output-ch {:parent-key {"untouched-key" "child value"}})
+    (async/close! output-ch)
+    (Thread/sleep 200)
+    (is (= (message-lines ["Content-Length: 45"
+                           ""
+                           "{\"parentKey\":{\"untouched-key\":\"child value\"}}"])
+           (.toString output-stream "utf-8")))))
+
+(deftest output-stream-should-set-content-length-to-number-of-bytes
+  (let [output-stream (java.io.ByteArrayOutputStream.)
+        output-ch (io-chan/output-stream->output-chan output-stream)]
+    (async/>!! output-ch {:key "apple"}) ;; 5 bytes
+    (async/>!! output-ch {:key "äpfel"}) ;; 6 bytes
+    (async/close! output-ch)
+    (Thread/sleep 200)
+    (is (= (message-lines ["Content-Length: 15"
+                           ""
+                           "{\"key\":\"apple\"}Content-Length: 16"
+                           ""
+                           "{\"key\":\"äpfel\"}"])
+           (.toString output-stream "utf-8")))))
+
+(deftest input-stream-should-kebab-case-input
+  (let [input-stream (mock-input-stream
+                       (message-lines
+                         ["Content-Length: 40"
+                          ""
+                          "{\"parentKey\":{\"childKey\":\"child value\"}}"]))
+        input-ch (io-chan/input-stream->input-chan input-stream)]
+    (is (= {:parent-key {:child-key "child value"}}
+           (h/assert-take input-ch)))))
+
+(deftest input-stream-should-read-number-of-bytes-from-content-length
+  (let [input-stream (mock-input-stream
+                       (message-lines
+                         ["Content-Length: 15"
+                          ""
+                          "{\"key\":\"apple\"}Content-Length: 16"
+                          ""
+                          "{\"key\":\"äpfel\"}"]))
+        input-ch (io-chan/input-stream->input-chan input-stream)]
+    (is (= {:key "apple"}
+           (h/assert-take input-ch)))
+    (is (= {:key "äpfel"}
+           (h/assert-take input-ch)))))
+
+(deftest input-stream-should-ignore-unexpected-headers
+  (let [input-stream (mock-input-stream
+                       (message-lines
+                         ["Content-Length: 15"
+                          "Referer: \"/\""
+                          ""
+                          "{\"key\":\"apple\"}"]))
+        input-ch (io-chan/input-stream->input-chan input-stream)]
+    (is (= {:key "apple"}
+           (h/assert-take input-ch)))))
+
+(deftest input-stream-should-return-parse-error
+  (testing "when content length is wrong"
+    (let [input-stream (mock-input-stream
+                         (message-lines
+                           ["Content-Length: 15"
+                            ""
+                            "{\"key\":\"äpfel\"}"]))
+          input-ch (io-chan/input-stream->input-chan input-stream)]
+      (is (= :parse-error (h/assert-take input-ch)))))
+  (testing "when content length is malformed"
+    (let [input-stream (mock-input-stream
+                         (message-lines
+                           ["Content-Length: nope"
+                            ""
+                            "{\"key\":\"apple\"}"]))
+          input-ch (io-chan/input-stream->input-chan input-stream)]
+      (is (= :parse-error (h/assert-take input-ch)))))
+  (testing "when content type is malformed"
+    (let [input-stream (mock-input-stream
+                         (message-lines
+                           ["Content-Length: 15"
+                            "Content-Type: application/vscode-jsonrpc; charset=nope"
+                            ""
+                            "{\"key\":\"apple\"}"]))
+          input-ch (io-chan/input-stream->input-chan input-stream)]
+      (is (= :parse-error (h/assert-take input-ch))))))

--- a/test/lsp4clj/io_server_test.clj
+++ b/test/lsp4clj/io_server_test.clj
@@ -1,8 +1,8 @@
 (ns lsp4clj.io-server-test
   (:require
    [clojure.core.async :as async]
-   [clojure.string :as string]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is]]
+   [lsp4clj.io-chan :as io-chan]
    [lsp4clj.io-server :as io-server]
    [lsp4clj.lsp.requests :as lsp.requests]
    [lsp4clj.server :as server]
@@ -10,120 +10,14 @@
 
 (set! *warn-on-reflection* true)
 
-(defn ^:private message-lines [arr]
-  (string/join "\r\n" arr))
-
-(defn mock-input-stream [^String input]
-  (java.io.ByteArrayInputStream. (.getBytes input "utf-8")))
-
-(deftest output-stream-should-camel-case-output
-  (let [output-stream (java.io.ByteArrayOutputStream.)
-        output-ch (io-server/output-stream->output-chan output-stream)]
-    (async/>!! output-ch {:parent-key {:child-key "child value"}})
-    (async/close! output-ch)
-    (Thread/sleep 200)
-    (is (= (message-lines ["Content-Length: 40"
-                           ""
-                           "{\"parentKey\":{\"childKey\":\"child value\"}}"])
-           (.toString output-stream "utf-8")))))
-
-(deftest output-stream-should-not-camel-case-string-map-keys
-  (let [output-stream (java.io.ByteArrayOutputStream.)
-        output-ch (io-server/output-stream->output-chan output-stream)]
-    (async/>!! output-ch {:parent-key {"untouched-key" "child value"}})
-    (async/close! output-ch)
-    (Thread/sleep 200)
-    (is (= (message-lines ["Content-Length: 45"
-                           ""
-                           "{\"parentKey\":{\"untouched-key\":\"child value\"}}"])
-           (.toString output-stream "utf-8")))))
-
-(deftest output-stream-should-set-content-length-to-number-of-bytes
-  (let [output-stream (java.io.ByteArrayOutputStream.)
-        output-ch (io-server/output-stream->output-chan output-stream)]
-    (async/>!! output-ch {:key "apple"}) ;; 5 bytes
-    (async/>!! output-ch {:key "äpfel"}) ;; 6 bytes
-    (async/close! output-ch)
-    (Thread/sleep 200)
-    (is (= (message-lines ["Content-Length: 15"
-                           ""
-                           "{\"key\":\"apple\"}Content-Length: 16"
-                           ""
-                           "{\"key\":\"äpfel\"}"])
-           (.toString output-stream "utf-8")))))
-
-(deftest input-stream-should-kebab-case-input
-  (let [input-stream (mock-input-stream
-                       (message-lines
-                         ["Content-Length: 40"
-                          ""
-                          "{\"parentKey\":{\"childKey\":\"child value\"}}"]))
-        input-ch (io-server/input-stream->input-chan input-stream)]
-    (is (= {:parent-key {:child-key "child value"}}
-           (h/assert-take input-ch)))))
-
-(deftest input-stream-should-read-number-of-bytes-from-content-length
-  (let [input-stream (mock-input-stream
-                       (message-lines
-                         ["Content-Length: 15"
-                          ""
-                          "{\"key\":\"apple\"}Content-Length: 16"
-                          ""
-                          "{\"key\":\"äpfel\"}"]))
-        input-ch (io-server/input-stream->input-chan input-stream)]
-    (is (= {:key "apple"}
-           (h/assert-take input-ch)))
-    (is (= {:key "äpfel"}
-           (h/assert-take input-ch)))))
-
-(deftest input-stream-should-ignore-unexpected-headers
-  (let [input-stream (mock-input-stream
-                       (message-lines
-                         ["Content-Length: 15"
-                          "Referer: \"/\""
-                          ""
-                          "{\"key\":\"apple\"}"]))
-        input-ch (io-server/input-stream->input-chan input-stream)]
-    (is (= {:key "apple"}
-           (h/assert-take input-ch)))))
-
-(deftest input-stream-should-return-parse-error
-  (testing "when content length is wrong"
-    (let [input-stream (mock-input-stream
-                         (message-lines
-                           ["Content-Length: 15"
-                            ""
-                            "{\"key\":\"äpfel\"}"]))
-          input-ch (io-server/input-stream->input-chan input-stream)]
-      (is (= :parse-error (h/assert-take input-ch)))))
-  (testing "when content length is malformed"
-    (let [input-stream (mock-input-stream
-                         (message-lines
-                           ["Content-Length: nope"
-                            ""
-                            "{\"key\":\"apple\"}"]))
-          input-ch (io-server/input-stream->input-chan input-stream)]
-      (is (= :parse-error (h/assert-take input-ch)))))
-  (testing "when content type is malformed"
-    (let [input-stream (mock-input-stream
-                         (message-lines
-                           ["Content-Length: 15"
-                            "Content-Type: application/vscode-jsonrpc; charset=nope"
-                            ""
-                            "{\"key\":\"apple\"}"]))
-          input-ch (io-server/input-stream->input-chan input-stream)]
-      (is (= :parse-error (h/assert-take input-ch))))))
-
-;; Integration test
-
 (deftest server-test
   (let [server-input-stream (java.io.PipedInputStream.)
         server-output-stream (java.io.PipedOutputStream.)
         client-input-stream (java.io.PipedInputStream. server-output-stream)
         client-output-stream (java.io.PipedOutputStream. server-input-stream)
         server (io-server/server {:in server-input-stream :out server-output-stream})
-        client-input-ch (io-server/input-stream->input-chan client-input-stream)
-        client-output-ch (io-server/output-stream->output-chan client-output-stream)
+        client-input-ch (io-chan/input-stream->input-chan client-input-stream)
+        client-output-ch (io-chan/output-stream->output-chan client-output-stream)
         join (server/start server nil)]
     ;; client initiates request
     (async/put! client-output-ch (lsp.requests/request 1 "foo" {}))

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -84,10 +84,10 @@
                                              (if (= :timeout resp)
                                                {:error :timeout}
                                                {:client-response (:response resp)})))]
-      (async/put! input-ch (messages/request 1 "initialize" {}))
+      (async/put! input-ch (lsp.requests/request 1 "initialize" {}))
       (let [client-rcvd-msg-1 (h/assert-take output-ch)]
         (is (= "window/showMessageRequest" (:method client-rcvd-msg-1)))
-        (async/put! input-ch (messages/response (:id client-rcvd-msg-1) {:response "ok"}))
+        (async/put! input-ch (lsp.responses/response (:id client-rcvd-msg-1) {:response "ok"}))
         (is (= {:jsonrpc "2.0"
                 :id 1
                 :result {:client-response "ok"}}

--- a/test/lsp4clj/socket_server_test.clj
+++ b/test/lsp4clj/socket_server_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.core.async :as async]
    [clojure.test :refer [deftest is]]
-   [lsp4clj.io-server :as io-server]
+   [lsp4clj.io-chan :as io-chan]
    [lsp4clj.lsp.requests :as lsp.requests]
    [lsp4clj.server :as server]
    [lsp4clj.socket-server :as socket-server]
@@ -29,8 +29,8 @@
         server* (future (socket-server/server {} socket-data))]
     (try
       (with-open [client (Socket. (.getInetAddress socket) (.getLocalPort socket))]
-        (let [client-input-ch (io-server/input-stream->input-chan (.getInputStream client))
-              client-output-ch (io-server/output-stream->output-chan (.getOutputStream client))
+        (let [client-input-ch (io-chan/input-stream->input-chan (.getInputStream client))
+              client-output-ch (io-chan/output-stream->output-chan (.getOutputStream client))
               server @server*
               join (server/start server nil)]
           (try


### PR DESCRIPTION
In clojure-lsp, the mock client used in integration tests needs
`input-stream->input-chan`. But, if the namespace that defines that
function also depends on `lsp4clj.server`, the integration tests don't
compile.

Rather than figure out why, this just separates the namespace that
defines `input-stream->input-chan`.

A namespace with these functions existed before and so after many moves
and renames, we've merely managed to separate `io-server/server` into its
own namespace.

@ericdallo this will be necessary to bump lsp4clj in `cli/bb.edn` in clojure-lsp.