### PR TITLE
Return nil from sending notification

### DIFF
--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -225,7 +225,8 @@
           notif (lsp.requests/notification method body)]
       (trace this trace/sending-notification notif now)
       ;; respect back pressure from clients that are slow to read; (go (>!)) will not suffice
-      (async/>!! output-ch notif)))
+      (async/>!! output-ch notif)
+      nil))
   (receive-response [this {:keys [id error result] :as resp}]
     (let [now (.instant clock)
           [pending-requests _] (swap-vals! pending-sent-requests* dissoc id)]

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -124,6 +124,15 @@
            (h/assert-take output-ch)))
     (server/shutdown server)))
 
+(deftest should-return-nil-after-sending-notifications
+  (let [input-ch (async/chan 3)
+        output-ch (async/chan 3)
+        server (server/chan-server {:output-ch output-ch
+                                    :input-ch input-ch})]
+    (server/start server nil)
+    (is (nil? (server/send-notification server "req" {:body "foo"})))
+    (server/shutdown server)))
+
 (deftest should-cancel-request-when-cancellation-notification-receieved
   (let [input-ch (async/chan 3)
         output-ch (async/chan 3)


### PR DESCRIPTION
We were returning `true`. This was causing a small bug in clojure-lsp where we expected send-notification to return nil.