### PR TITLE
Let language servers abort cancelled running requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Let language servers abort running requests that a client has cancelled.
+
 ## v1.4.0
 
 - Let language servers pick detail of traces, by setting `:trace-level`. #27


### PR DESCRIPTION
See the README for an explanation for why this is necessary. clojure-lsp needs it so that it can abort process-after-changes requests, which otherwise will run even if they are cancelled.