### PR TITLE
Add license information to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,13 @@
   <artifactId>lsp4clj</artifactId>
   <version>1.5.0</version>
   <name>lsp4clj</name>
+  <licenses>
+    <license>
+      <name>The MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>


### PR DESCRIPTION
`lsp4clj` is distributed under the MIT license, but this is not reflected in the `pom.xml`. Therefore tools like `clojure -T:deps list` will not recognise the license.

This PR adds a `<licenses>` tag to `pom.xml`.