### PR TITLE
Buffer I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Buffer I/O, slightly reducing latency.
+
 ## v1.5.0
 
 - Let language servers abort running requests that a client has cancelled.
@@ -66,7 +68,7 @@ see https://github.com/clojure-lsp/clojure-lsp/pull/1117
 
 ## v0.2.0
 
-- Support LSP 3.16 file operations: `workspace/willRenameFiles`, `workspace/didRenameFiles`, 
+- Support LSP 3.16 file operations: `workspace/willRenameFiles`, `workspace/didRenameFiles`,
 `workspace/willCreateFiles`, `workspace/didCreateFiles`, `workspace/willDeleteFiles`, `workspace/didDeleteFiles`.
 
 ## v0.0.1

--- a/src/lsp4clj/io_chan.clj
+++ b/src/lsp4clj/io_chan.clj
@@ -4,6 +4,7 @@
    [camel-snake-kebab.extras :as cske]
    [cheshire.core :as json]
    [clojure.core.async :as async]
+   [clojure.java.io :as io]
    [clojure.string :as string])
   (:import
    (java.io EOFException InputStream OutputStream)))
@@ -88,9 +89,10 @@
 
   Reads in a thread to avoid blocking a go block thread."
   ([input] (input-stream->input-chan input {}))
-  ([^InputStream input {:keys [close? keyword-function]
-                        :or {close? true, keyword-function csk/->kebab-case-keyword}}]
-   (let [messages (async/chan 1)]
+  ([input {:keys [close? keyword-function]
+           :or {close? true, keyword-function csk/->kebab-case-keyword}}]
+   (let [input (io/input-stream input)
+         messages (async/chan 1)]
      (async/thread
        (loop [headers {}]
          (let [line (read-header-line input)]
@@ -112,8 +114,9 @@
   channel is closed, closes the output.
 
   Writes in a thread to avoid blocking a go block thread."
-  [^OutputStream output]
-  (let [messages (async/chan 1)]
+  [output]
+  (let [output (io/output-stream output)
+        messages (async/chan 1)]
     (async/thread
       (with-open [writer output] ;; close output when channel closes
         (loop []

--- a/src/lsp4clj/socket_server.clj
+++ b/src/lsp4clj/socket_server.clj
@@ -42,6 +42,6 @@
                      (.close conn)
                      (.close socket))]
      (io-server/server (assoc opts
-                              :in (.getInputStream conn)
-                              :out (.getOutputStream conn)
+                              :in conn
+                              :out conn
                               :on-close on-close)))))

--- a/test/lsp4clj/io_chan_test.clj
+++ b/test/lsp4clj/io_chan_test.clj
@@ -12,7 +12,7 @@
   (string/join "\r\n" arr))
 
 (defn mock-input-stream [^String input]
-  (java.io.ByteArrayInputStream. (.getBytes input "utf-8")))
+  (.getBytes input "utf-8"))
 
 (deftest output-stream-should-camel-case-output
   (let [output-stream (java.io.ByteArrayOutputStream.)

--- a/test/lsp4clj/socket_server_test.clj
+++ b/test/lsp4clj/socket_server_test.clj
@@ -29,8 +29,8 @@
         server* (future (socket-server/server {} socket-data))]
     (try
       (with-open [client (Socket. (.getInetAddress socket) (.getLocalPort socket))]
-        (let [client-input-ch (io-chan/input-stream->input-chan (.getInputStream client))
-              client-output-ch (io-chan/output-stream->output-chan (.getOutputStream client))
+        (let [client-input-ch (io-chan/input-stream->input-chan client)
+              client-output-ch (io-chan/output-stream->output-chan client)
               server @server*
               join (server/start server nil)]
           (try


### PR DESCRIPTION
Reduce latency introduced by ***lsp4clj*** by using buffered input and output streams.

In theory, it's faster to read data off the underlying stream in chunks, even though sometimes we need to process them one byte at a time. In practice the difference is probably minimal, though it doesn't hurt.

This uses `clojure.java.io/input-stream` and `output-stream` to create the buffered streams, which has the side-benefit of cleaning up the `socket-server` code slightly.