### PR TITLE
Fix progress messages in Calva

### DIFF
--- a/src/lsp4clj/lsp/requests.clj
+++ b/src/lsp4clj/lsp/requests.clj
@@ -16,6 +16,9 @@
 ;; TODO: The following are helpers used by servers, but not by lsp4clj itself.
 ;; Perhaps they belong in a utils namespace.
 
+(defn clamp [n n-min n-max]
+  (-> n (max n-min) (min n-max)))
+
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn work-done-progress
   "Returns the params for a WorkDone $/progress notification.
@@ -23,12 +26,21 @@
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgress
   "
   [percentage message progress-token]
-  (let [percentage (int percentage)
-        progress {:kind (case percentage
-                          0 :begin
-                          100 :end
-                          :report)
-                  :title message
-                  :percentage percentage}]
-    {:token (or progress-token "lsp4clj")
-     :value progress}))
+  (when progress-token
+    (let [percentage (int (clamp percentage 0 100))
+          progress (case percentage
+                     ;; TODO: this is a bit restricting. Technically the 'begin'
+                     ;; message can start at a higher `percentage`, and it can
+                     ;; have a `message`. To work around this, it's possible to
+                     ;; publish a 'begin' immediately followed by a 'progress'
+                     ;; with the desired percentage and message.
+                     0 {:kind :begin
+                        :title message
+                        :percentage 0}
+                     100 {:kind :end
+                          :message message}
+                     {:kind :report
+                      :message message
+                      :percentage percentage})]
+      {:token progress-token
+       :value progress})))


### PR DESCRIPTION
The helper to generate progress messages was incorrectly using the :title key in :report messages. That key should only be used with :begin messages. This changes the helper to generate valid progress messages.

After lsp4clj is bumped in clojure-lsp, Calva will show progress messages during startup. Emacs was showing progress messages before this fix, so it must observe the non-standard :title key.

I've also noticed that Calva doesn't show percentages in its UI. So, as a future enhancement to clojure-lsp, we may want to embed percentages in the messages themselves "36%", or perhaps add something like "file 26/235".