### PR TITLE
Avoid dropping client messages

### DIFF
--- a/.clj-kondo/funcool/promesa/config.edn
+++ b/.clj-kondo/funcool/promesa/config.edn
@@ -5,4 +5,5 @@
            promesa.core/plet        clojure.core/let
            promesa.core/loop        clojure.core/loop
            promesa.core/recur       clojure.core/recur
-           promesa.core/with-redefs clojure.core/with-redefs}}
+           promesa.core/with-redefs clojure.core/with-redefs
+           promesa.core/doseq       clojure.core/doseq}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
-- Server requests can be treated as promesa promises.
+- Avoid blocking client responses behind client requests or notifications.
 - In certain situations the server will abort its pending sent requests to avoid
   blocking the client's messages.
+- Server requests can be treated as promesa promises.
+- Bump promesa to `10.0.594`
 
 ## v1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Server requests can be treated as promesa promises.
-- In certain blocking situations server will drop its pending sent requests to
-  prioritize the client's messages.
+- In certain situations the server will abort its pending sent requests to avoid
+  blocking the client's messages.
 
 ## v1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Server requests can be treated as promesa promises.
+
 ## v1.8.1
 
 - Bump promesa to `10.0.571`
@@ -15,6 +17,8 @@
 - Deprecate `lsp4clj.socket-server` and document preferred alternative in the README.
 
 ## v1.7.3
+
+- Server continues receiving responses while it is blocking requests or notifications.
 
 ## v1.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Server requests can be treated as promesa promises.
+- In certain blocking situations server will drop its pending sent requests to
+  prioritize the client's messages.
 
 ## v1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Avoid blocking client responses behind client requests or notifications.
 - In certain situations the server will abort its pending sent requests to avoid
   blocking the client's messages.
 - Server requests can be treated as promesa promises.

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/core.async {:mvn/version "1.5.648"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
         cheshire/cheshire {:mvn/version "5.11.0"}
-        funcool/promesa {:mvn/version "10.0.571"}}
+        funcool/promesa {:mvn/version "10.0.594"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.64.1010"}}
                   :extra-paths ["test"]

--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -38,10 +38,10 @@
   (deref [_ timeout-ms timeout-val]
     (deref p timeout-ms timeout-val))
   IBlockingDerefOrCancel
-  (deref-or-cancel [this timeout-ms timeout-val]
+  (deref-or-cancel [_ timeout-ms timeout-val]
     (let [result (deref p timeout-ms ::timeout)]
       (if (identical? ::timeout result)
-        (do (future-cancel this)
+        (do (p/cancel! p)
             timeout-val)
         result)))
   clojure.lang.IPending

--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -228,7 +228,7 @@
           ;; To accomplish this we processes inbound requests and notifications
           ;; separately from inbound responses. If the server starts blocking
           ;; waiting for a response, we buffer the inbound requests and
-          ;; notificatons until the server is prepared to process them.
+          ;; notifications until the server is prepared to process them.
 
           ;; If the buffer becomes full, we assume that the server isn't
           ;; handling inbound requests and notifcations because it's waiting for
@@ -241,7 +241,7 @@
 
           ;; This ensures we don't drop any client messages, though we could
           ;; stop reading them if the server keeps blocking. If we're lucky
-          ;; either the language server will unblock, or the client will decided
+          ;; either the language server will unblock, or the client will decide
           ;; to stop sending messages because it's failed to receive a server
           ;; response (i.e., we will have managed to apply backpressure to the
           ;; client). If we're unlucky, the server could keep blocking forever.

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -385,11 +385,15 @@
           _ (server/start server nil)
           req (p/promise (server/send-request server "req" {:body "foo"}))
           client-rcvd-msg (h/assert-take output-ch)]
-      (async/put! input-ch (lsp.responses/response (:id client-rcvd-msg) {:processed 1}))
-      (is (= {:processed 2} (-> req
-                                (p/timeout 1000 :test-timeout)
-                                (p/then #(update % :processed inc))
-                                (p/extract))))
+      (async/put! input-ch (lsp.responses/response (:id client-rcvd-msg) {:result :processed
+                                                                          :value 1}))
+      (is (= {:result :processed
+              :value 2}
+             (-> req
+                 (p/timeout 1000 {:result :test-timeout
+                                  :value 1})
+                 (p/then #(update % :value inc))
+                 (deref))))
       (is (p/done? req))
       (is (p/resolved? req))
       (is (not (p/rejected? req)))

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -203,7 +203,7 @@
         (is (h/assert-no-take output-ch))
         ;; The client sends one more mesage, which is too many for the server to buffer.
         (client-req {:server-action :overflow})
-        ;; To prioritize the client's inbound messages, the server's outbound
+        ;; To avoid blocking the client's inbound messages, the server's outbound
         ;; request is aborted, causing it to stop waiting for a client response.
         (is (= {:jsonrpc "2.0", :id 1, :error {:result :deref-aborted}}
                (h/assert-take output-ch)))

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -290,7 +290,7 @@
     (h/assert-take output-ch)
     (is (future-cancel req))
     (is (= "$/cancelRequest" (:method (h/assert-take output-ch))))
-    (is (not (future-cancel req)))
+    (is (future-cancel req))
     (h/assert-no-take output-ch)
     (server/shutdown server)))
 
@@ -402,9 +402,12 @@
                                       :input-ch input-ch})
           _ (server/start server nil)
           req (p/promise (server/send-request server "req" {:body "foo"}))]
+      (h/assert-take output-ch)
       (p/cancel! req)
       (is (p/done? req))
       (is (p/cancelled? req))
+      (is (= {:jsonrpc "2.0", :method "$/cancelRequest", :params {:id 1}}
+             (h/assert-take output-ch)))
       (server/shutdown server))))
 
 (def fixed-clock


### PR DESCRIPTION
@ferdinand-beyer this is a draft of the changes you [suggested](https://github.com/clojure-lsp/lsp4clj/pull/37#discussion_r1136615400). Is it roughly what you were thinking? I have some questions/concerns below about whether all of this is the right way to go. Will you review?

## Pending Sent Requesets

* A pending sent request is now mostly a wrapper around a promesa deferred, and can be used as one.
* That simplified many things, but I couldn't figure out how to make `p/cancel!` send `$/cancelRequest`. It'd be nice (and intuitive) if it did. 
  * `$/cancelRequest` is still exposed through `deref-or-cancel`, which, under the hood, uses `java.util.concurrent.Future/cancel`, or equivalently, `clojure.core/future-cancel`.
  * I wasn't sure how to make the pending sent request both _return_ a promise via `IPromiseFactory` and _be_ a promise in the sense of implementing `promesa.protocols/ICancellable`. If I were to do it again, I don't think I'd make `PendingRequest` implement so many interfaces, because promesa's promises already implement many of those same interfaces. Instead, I think I'd prefer if you could get to those interfaces via the promise. Should we just move forward with that? It might be best to do in a v2.
* If the client returns an error, the pending request is resolved (not rejected as you might expect.) That's because:
  * `p/reject!` expects an exception, whereas the client's response isn't exactly an exception, but is instead a result with a special interpretation—that an error of some sort happened on the client side,
  * and, because the language servers are designed to `deref` an error _result_, not `(p/catch ...)` an _exception_.

## Dropping messages

* As you suggested, when the buffer of client-initiated input fills up we now reject our pending sent requests, then park.
* However, I'm having trouble reasoning about whether this strategy really makes sense. We suspect that the reason the client-initiated input has filed up is because the server is blocking on something, and not getting to the client's messages. But a pending sent request is only one of many things the server might be blocking on. Cancelling all the pending sent requests _might_ unblock the server, but the server might have been blocked on something else entirely. In fact, there might not even be any pending sent requests to reject.
* Your original proposal treated the server-initiated input symmetrically, rejecting the client's messages.
  * On reflection, I don't think that's advisable. That would prioritize the server's messages over the client's, which isn't really what we want.
  * So, I've left that part as a sliding-buffer. However, perhaps it should be a fixed-size buffer. In either case, I'm still not sure how to reason about how big that buffer should be.
* Originally, the sliding-buffer was 100 messages. I bumped this number to 1024, and I'm using it for both the sliding-buffer for server-initiated messages, and as the fixed-size buffer for client-initiated messages. I have no reason for this change, except that it's the number that core.async uses internally for when it starts rejecting `put!`s.

This whole series of changes makes me wonder if lsp4clj would be better if it were built mostly on promesa (or manifold, or...), not on core.async. It feels like we have an unholy mixture of the two at the moment. Switching those underpinnings might not even involve many changes to `clojure-lsp` and Scarlet, because they don't really work down at the `chan-server` level, which is the current base of the lsp4clj functionality. On the other hand, it might just be trading one set of problems for another. Something to think about for v2, if that day ever comes.