### PR TITLE
Close output channel on error

### DIFF
--- a/src/lsp4clj/io_chan.clj
+++ b/src/lsp4clj/io_chan.clj
@@ -128,6 +128,10 @@
       (with-open [writer output] ;; close output when channel closes
         (loop []
           (when-let [msg (async/<!! messages)]
-            (write-message writer msg)
+            (try
+              (write-message writer msg)
+              (catch Throwable e
+                (async/close! messages)
+                (throw e)))
             (recur)))))
     messages))

--- a/test/lsp4clj/io_chan_test.clj
+++ b/test/lsp4clj/io_chan_test.clj
@@ -70,14 +70,14 @@
   (testing "when JSON serialisation fails"
     (let [output-stream (java.io.ByteArrayOutputStream.)
           output-ch (io-chan/output-stream->output-chan output-stream)]
-      (async/>!! output-ch {:not-serializable output-stream})
-      (Thread/sleep 200)
+      (async/>!! output-ch {:not-serializable (Object.)})
+      (Thread/sleep 50)
       (is (false? (async/put! output-ch {:test "should be closed"})))))
   (testing "when an I/O exception occurs"
     (let [output-stream (error-output-stream)
           output-ch (io-chan/output-stream->output-chan output-stream)]
       (async/>!! output-ch {:test "ok"})
-      (Thread/sleep 200)
+      (Thread/sleep 50)
       (is (false? (async/put! output-ch {:test "should be closed"}))))))
 
 (deftest input-stream-should-kebab-case-input


### PR DESCRIPTION
Fixes #41

This approach closes the output _channel_ when writing a message to the output _stream_ fails for any reason. Expected reasons are:

- I/O exception
- JSON encoding exception

This will prevent the server from blocking forever on a channel that has no more consumers. Instead, messages will be dropped.

We expect that the client will send an exit message and eventually close the connection. This will close the server's input channel and allow it to terminate.