### PR TITLE
Complete pending server-initiated request promises on default executor

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -3,8 +3,8 @@
  :remove-consecutive-blank-lines? true
  :insert-missing-whitespace? true
  :align-associative? false
- :indents {#re "^(?!catch-kondo-errors).*" [[:block 0]]
-           catch-kondo-errors [[:inner 0]]}
+ :extra-indents {#re "^(?!catch-kondo-errors).*" [[:block 0]]
+                 catch-kondo-errors [[:inner 0]]}
  :test-code
  (comment
    (:require

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a `:response-executor` option to control on which thread responses to
+  server-initiated requests are run, defaulting to Promesa's `:default`
+  executor, i.e. `ForkJoinPool/commonPool`.
+
 ## v1.10.0
 
 - Add `textDocument/foldingRange` schemas.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Alternatively, you can convert the request to a promesa promise, and handle it u
 
 In this case `(promesa/cancel! request)` will send `$/cancelRequest`.
 
+Response promises are completed on Promesa's `:default` executor.  You
+can specify your own executor by passing the `:response-executor` option
+when creating your server instance.
+
 ### Start and stop a server
 
 The last step is to start the server you created earlier. Use `lsp4clj.server/start`. This method accepts two arguments, the server and a "context".

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,8 @@
         cheshire/cheshire {:mvn/version "5.11.0"}
         funcool/promesa {:mvn/version "10.0.594"}}
  :paths ["src" "resources"]
- :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.64.1010"}}
+ :aliases {:dev {:extra-paths ["test"]}
+           :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.64.1010"}}
                   :extra-paths ["test"]
                   :main-opts ["-m" "kaocha.runner"]}
            :build {:extra-paths ["resources"]

--- a/src/lsp4clj/server.clj
+++ b/src/lsp4clj/server.clj
@@ -352,9 +352,12 @@
           (do
             (trace this trace/received-response req resp started now)
             ;; Note that we are called from the server's pipeline, a core.async
-            ;; go-loop, and therefore must not block.  Callbacks of the pending
-            ;; request's promise will be executed in the completing thread,
-            ;; which should not be our thread.  This is very easy for users to
+            ;; go-loop, and therefore must not block. Callbacks of the pending
+            ;; request's promise (`p`) will be executed in the completing
+            ;; thread, whatever that thread is. Since the callbacks are not
+            ;; under our control, they are under our users' control, they could
+            ;; block. Therefore, we do not want the completing thread to be our
+            ;; thread. This is very easy for users to
             ;; miss, therefore we complete the promise on the default executor.
             (p/thread-call :default
                            (fn []

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -488,14 +488,10 @@
   (testing "current thread"
     (is (not (core-async-dispatch-thread? (Thread/currentThread)))))
   (testing "thread running go blocks"
-    (let [ch (async/chan)
-          _ (async/go (async/>! ch (Thread/currentThread)))
-          thread (async/<!! ch)]
+    (let [thread (async/<!! (async/go (Thread/currentThread)))]
       (is (core-async-dispatch-thread? thread))))
   (testing "thread running core.async thread macro"
-    (let [ch (async/chan)
-          _ (async/thread (async/>!! ch (Thread/currentThread)))
-          thread (async/<!! ch)]
+    (let [thread (async/<!! (async/thread (Thread/currentThread)))]
       (is (not (core-async-dispatch-thread? thread))))))
 
 (deftest request-should-complete-on-a-suitable-executor

--- a/test/lsp4clj/server_test.clj
+++ b/test/lsp4clj/server_test.clj
@@ -481,6 +481,73 @@
              (h/assert-take output-ch)))
       (server/shutdown server))))
 
+(defn- core-async-dispatch-thread? [^Thread thread]
+  (re-matches #"async-dispatch-\d+" (.getName thread)))
+
+(deftest can-determine-core-async-dispatch-thread
+  (testing "current thread"
+    (is (not (core-async-dispatch-thread? (Thread/currentThread)))))
+  (testing "thread running go blocks"
+    (let [ch (async/chan)
+          _ (async/go (async/>! ch (Thread/currentThread)))
+          thread (async/<!! ch)]
+      (is (core-async-dispatch-thread? thread))))
+  (testing "thread running core.async thread macro"
+    (let [ch (async/chan)
+          _ (async/thread (async/>!! ch (Thread/currentThread)))
+          thread (async/<!! ch)]
+      (is (not (core-async-dispatch-thread? thread))))))
+
+(deftest request-should-complete-on-a-suitable-executor
+  (testing "successful completion"
+    (let [input-ch (async/chan 3)
+          output-ch (async/chan 3)
+          server (server/chan-server {:output-ch output-ch
+                                      :input-ch input-ch})
+          _ (server/start server nil)
+          thread-p (-> (server/send-request server "req" {:body "foo"})
+                       (p/then (fn [_] (Thread/currentThread))))
+          client-rcvd-msg (h/assert-take output-ch)
+          _ (async/put! input-ch (lsp.responses/response (:id client-rcvd-msg) {:result "good"}))
+          thread (deref thread-p 100 nil)]
+      (is (not (core-async-dispatch-thread? thread)))
+      (is (instance? java.util.concurrent.ForkJoinWorkerThread thread)
+          "completes on default ForkJoinPool executor")
+      (server/shutdown server)))
+  (testing "exceptional completion"
+    (let [input-ch (async/chan 3)
+          output-ch (async/chan 3)
+          server (server/chan-server {:output-ch output-ch
+                                      :input-ch input-ch})
+          _ (server/start server nil)
+          thread-p (-> (server/send-request server "req" {:body "foo"})
+                       (p/catch (fn [_] (Thread/currentThread))))
+          client-rcvd-msg (h/assert-take output-ch)
+          _ (async/put! input-ch
+                        (-> (lsp.responses/response (:id client-rcvd-msg))
+                            (lsp.responses/error {:code 1234
+                                                  :message "Something bad"
+                                                  :data {:body "foo"}})))
+          thread (deref thread-p 100 nil)]
+      (is (not (core-async-dispatch-thread? thread)))
+      (is (instance? java.util.concurrent.ForkJoinWorkerThread thread)
+          "completes on default ForkJoinPool executor")
+      (server/shutdown server)))
+  (testing "completion with :current-thread executor for legacy behavior"
+    (let [input-ch (async/chan 3)
+          output-ch (async/chan 3)
+          server (server/chan-server {:output-ch output-ch
+                                      :input-ch input-ch
+                                      :response-executor :current-thread})
+          _ (server/start server nil)
+          thread-p (-> (server/send-request server "req" {:body "foo"})
+                       (p/then (fn [_] (Thread/currentThread))))
+          client-rcvd-msg (h/assert-take output-ch)
+          _ (async/put! input-ch (lsp.responses/response (:id client-rcvd-msg) {:result "good"}))
+          thread (deref thread-p 100 nil)]
+      (is (core-async-dispatch-thread? thread) "completes on core.async dispatch thread")
+      (server/shutdown server))))
+
 (def fixed-clock
   (-> (java.time.LocalDateTime/of 2022 03 05 13 35 23 0)
       (.toInstant java.time.ZoneOffset/UTC)


### PR DESCRIPTION
There's a subtle detail on Promesa promises (`CompletableFuture`): Unless an executor is specified, callbacks will be executed on the thread that completed the promise.

For `lsp4clj`, this means that users need to be careful when using `send-request` and coercing the result to a Promesa promise: The code run in handlers such as `p/then` or `p/catch` will end up running in a core.async dispatch thread, as the promise is completed from within a `go-loop`.

Since go blocks are executed in a fixed-size thread pool, one should not block in go blocks. Consequently, users should not block in code that handles the `send-request` promise, unless they explicitly move it to a different executor.

This is easy to get wrong, especially with Promesa's convenience macros like `p/let`, which will coerce the `PendingRequest` to a promise without a dedicated executor. Furthermore, Promesa does not expose `CompletionStage.exceptionallyAsync()`, i.e. it does not support specifying an executor with `p/catch`, therefore it is not trivial to ensure all continuation happens in another thread.

This PR attempts to improve this by completing the promise in a thread from the `:default` executor (`(ForkJoinPool/commonPool)`), instead of the calling thread.

---

Some caveats to this approach:

- There's some overhead even when the promise does not have any continuation handlers (apart from the `CancellationException` we handle ourselves, which, since it blocks on a `send-notification` call, should also run on a suitable executor)
- We don't allow users to customise the executor, but use promesa's default, which is `(ForkJoinPool/commonPool)`. Users might prefer to use a virtual thread executor instead. We could add a `:response-executor` option for this?

---

The change to `.cljfmt.edn` is unrelated, but required for more recent version of cljfmt, as used by Calva, for example. This could be moved to a different PR of course.