### PR TITLE
Add mcp-clojure-sdk as a known user of lsp4clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ lsp4clj provides one tool to avoid accidental writes to stdout (or rather to `*o
 ## Known lsp4clj users
 
 - [clojure-lsp](https://clojure-lsp.io/): A Clojure LSP server implementation.
+- [mcp-clojure-sdk](https://github.com/unravel-team/mcp-clojure-sdk): A Clojure MCP SDK for writing MCP servers.
 
 ## Release
 


### PR DESCRIPTION
I'm the author of [mcp-clojure-sdk](https://github.com/unravel-team/mcp-clojure-sdk).

I've implemented the [MCP](https://modelcontextprotocol.io/introduction) STDIO server using `lsp4clj`, after originally implementing it by hand. `lsp4clj` had already solved a number of issues I stumbled into, and the rewrite on top of lsp4clj was smooth and easy. 

Thank you for an excellent library that made my job so easy.